### PR TITLE
Fix automatic build and update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine as build
 
-COPY . /usr/src/fritzbox_exporter
 WORKDIR /usr/src/fritzbox_exporter
+COPY . .
 
 RUN go mod download; \
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-w -extldflags "-static"' -o fritzbox-exporter .

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -4,8 +4,8 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-COPY . /usr/src/fritzbox_exporter
 WORKDIR /usr/src/fritzbox_exporter
+COPY . .
 
 RUN go mod download; \
 	case "$TARGETVARIANT" in \

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,12 +1,21 @@
-FROM golang:alpine as build
+FROM --platform=$BUILDPLATFORM golang:alpine as build
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 COPY . /usr/src/fritzbox_exporter
 WORKDIR /usr/src/fritzbox_exporter
 
 RUN go mod download; \
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-w -extldflags "-static"' -o fritzbox-exporter .
+	case "$TARGETVARIANT" in \
+		v5) export GOARM=5 ;; \
+		v6) export GOARM=6 ;; \
+		v7) export GOARM=7 ;; \
+	esac; \
+	CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags '-w -extldflags "-static"' -o fritzbox-exporter .
 
-FROM alpine:latest
+FROM --platform=$TARGETPLATFORM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY --from=build /usr/src/fritzbox_exporter/fritzbox-exporter /bin/
 COPY --from=build /usr/src/fritzbox_exporter/*.json /etc/fritzbox-exporter/


### PR DESCRIPTION
Last time I created a pr I didn't know that the docker hub cannot build automatic multiarch images. That is actually possible by using GitHub actions and load a qemu image into the building process to emulate arm and others during build but I would have to look into how to set it up correctly.
For now I would like to correct my mistake by reverting back to an amd64 only Dockerfile and instead add the multiarch image for building with buildx separately.
In addition this pr serves as a fix for the missing lua-metrics-file argument that is required as the necessary json files are places in `/etc/fritzbox-exporter`, to adjust some paths and to use an updated (golang 1.16.x) alpine base image for the building stage. :)